### PR TITLE
Support all data types for event and visitor properties

### DIFF
--- a/woopra/src/main/java/com/woopra/tracking/android/Utils.java
+++ b/woopra/src/main/java/com/woopra/tracking/android/Utils.java
@@ -10,12 +10,12 @@ import java.util.UUID;
 public class Utils {
     /**
      *
-     * @param fristKey
+     * @param firstKey
      * @param secondKey
      * @return
      */
-    public static String getUUID(String fristKey, String secondKey) {
-        long mostSigBits = fristKey.hashCode();
+    public static String getUUID(String firstKey, String secondKey) {
+        long mostSigBits = firstKey.hashCode();
         long leastSigBits = secondKey.hashCode();
         UUID generateUUID = new UUID(mostSigBits, leastSigBits);
         String result = generateUUID.toString();

--- a/woopra/src/main/java/com/woopra/tracking/android/WoopraEvent.java
+++ b/woopra/src/main/java/com/woopra/tracking/android/WoopraEvent.java
@@ -30,10 +30,10 @@ import java.util.Map;
  * @author Woopra on 1/26/2013
  *
  */
-public class WoopraEvent implements Runnable{
+public class WoopraEvent implements Runnable {
 
 	private WoopraTracker tracker;
-	private final Map<String, String> properties = new ConcurrentHashMap<String, String>();
+	private final Map<String, Object> properties = new ConcurrentHashMap<>();
 	private String eventName;
 	private long timestamp = -1;
 
@@ -48,7 +48,7 @@ public class WoopraEvent implements Runnable{
 	 * @param eventName
 	 * @param properties
 	 */
-	public WoopraEvent(String eventName, Map<String, String> properties) {
+	public WoopraEvent(String eventName, Map<String, Object> properties) {
 		this.eventName = eventName;
 		if (properties != null) {
 			this.properties.putAll(properties);
@@ -60,7 +60,7 @@ public class WoopraEvent implements Runnable{
 	 * @param tracker
 	 */
 	public void setTracker(WoopraTracker tracker){
-		this.tracker=tracker;
+		this.tracker = tracker;
 	}
 
 	/**
@@ -87,7 +87,7 @@ public class WoopraEvent implements Runnable{
 	/**
 	 * @return
 	 */
-	public Map<String, String> getProperties() {
+	public Map<String, Object> getProperties() {
 		return properties;
 	}
 
@@ -95,14 +95,14 @@ public class WoopraEvent implements Runnable{
 	 * @param newProperties
 	 */
 	@Deprecated
-	public void setEventProperty(Map<String, String> newProperties) {
+	public void setEventProperty(Map<String, Object> newProperties) {
 		properties.putAll(newProperties);
 	}
 
 	/**
 	 * @param newProperties
 	 */
-	public void setProperties(Map<String, String> newProperties) {
+	public void setProperties(Map<String, Object> newProperties) {
 		properties.putAll(newProperties);
 	}
 
@@ -111,7 +111,7 @@ public class WoopraEvent implements Runnable{
 	 * @param value
 	 */
 	@Deprecated
-	public void setEventProperty(String key, String value) {
+	public void setEventProperty(String key, Object value) {
 		properties.put(key, value);
 	}
 
@@ -119,7 +119,7 @@ public class WoopraEvent implements Runnable{
 	 * @param key
 	 * @param value
 	 */
-	public void setProperty(String key, String value) {
+	public void setProperty(String key, Object value) {
 		properties.put(key, value);
 	}
 
@@ -198,13 +198,13 @@ public class WoopraEvent implements Runnable{
             }
 
             // Add visitors properties
-            for (Map.Entry<String, String> entry : tracker.getWoopraContext().getVisitor().getProperties().entrySet()) {
+            for (Map.Entry<String, Object> entry : tracker.getWoopraContext().getVisitor().getProperties().entrySet()) {
                 postBody.put("cv_" + entry.getKey(), entry.getValue());
             }
 
             postBody.put("event", getName());
             // Add Event properties
-            for (Map.Entry<String, String> entry : getProperties().entrySet()) {
+            for (Map.Entry<String, Object> entry : getProperties().entrySet()) {
                 postBody.put("ce_" + entry.getKey(), entry.getValue());
             }
             Log.d(WoopraEvent.class.getName(), "Track event: " + getName());

--- a/woopra/src/main/java/com/woopra/tracking/android/WoopraIdentify.java
+++ b/woopra/src/main/java/com/woopra/tracking/android/WoopraIdentify.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * @author Woopra on 1/26/2013
  *
  */
-public class WoopraIdentify implements Runnable{
+public class WoopraIdentify implements Runnable {
 
     private WoopraTracker tracker;
 
@@ -56,7 +56,7 @@ public class WoopraIdentify implements Runnable{
                     .put("timeout", tracker.getIdleTimeout());
 
             // Add visitors properties
-            for (Map.Entry<String, String> entry : tracker.getWoopraContext().getVisitor().getProperties().entrySet()) {
+            for (Map.Entry<String, Object> entry : tracker.getWoopraContext().getVisitor().getProperties().entrySet()) {
                 postBody.put("cv_" + entry.getKey(), entry.getValue());
             }
 

--- a/woopra/src/main/java/com/woopra/tracking/android/WoopraTracker.java
+++ b/woopra/src/main/java/com/woopra/tracking/android/WoopraTracker.java
@@ -27,7 +27,7 @@ import android.util.Log;
  */
 public class WoopraTracker {
 
-	private final static ExecutorService executor = Executors.newFixedThreadPool(1);;
+	private final static ExecutorService executor = Executors.newFixedThreadPool(1);
 
 
 	private final Woopra woopraContext;
@@ -36,7 +36,8 @@ public class WoopraTracker {
 	private long idleTimeoutMs = 30000;
 
 	//
-	private String referer = null, deviceType=null;
+	private String referer = null;
+	private String deviceType = null;
 
 	/**
 	 *
@@ -45,7 +46,7 @@ public class WoopraTracker {
 	 */
 	public WoopraTracker(String domain, Woopra woopraContext) {
 		this.domain = domain;
-		this.woopraContext=woopraContext;
+		this.woopraContext = woopraContext;
 	}
 
 	/**
@@ -70,8 +71,8 @@ public class WoopraTracker {
 	/**
 	 *
 	 */
-	public boolean push(){
-		WoopraIdentify identify=new WoopraIdentify(this);
+	public boolean push() {
+		WoopraIdentify identify = new WoopraIdentify(this);
 		executor.submit(identify);
 		return true;
 	}
@@ -171,8 +172,8 @@ public class WoopraTracker {
 	 * @param key
 	 * @param value
 	 */
-	public void setVisitorProperty(String key, String value) {
-	  if (key!=null && value != null) {
+	public void setVisitorProperty(String key, Object value) {
+	  if (key != null && value != null) {
 		  woopraContext.getVisitor().setProperty(key, value);
 	  }
 	}
@@ -181,7 +182,7 @@ public class WoopraTracker {
 	 *
 	 * @param newProperties
 	 */
-	public synchronized void setVisitorProperties(Map<String,String> newProperties) {
+	public synchronized void setVisitorProperties(Map<String, Object> newProperties) {
 		woopraContext.getVisitor().setProperties(newProperties);
 	}
  

--- a/woopra/src/main/java/com/woopra/tracking/android/WoopraVisitor.java
+++ b/woopra/src/main/java/com/woopra/tracking/android/WoopraVisitor.java
@@ -30,7 +30,7 @@ public class WoopraVisitor {
 
 
 	private String cookie;
-	private final Map<String, String> properties = new java.util.concurrent.ConcurrentHashMap<String, String>();
+	private final Map<String, Object> properties = new java.util.concurrent.ConcurrentHashMap<>();
 
 	private WoopraVisitor() {
 	}
@@ -107,7 +107,7 @@ public class WoopraVisitor {
 	 *
 	 * @return
 	 */
-	public Map<String,String> getProperties() {
+	public Map<String, Object> getProperties() {
 		return properties;
 	}
 
@@ -115,7 +115,7 @@ public class WoopraVisitor {
 	 *
 	 * @param newProperties
 	 */
-	public void setProperties(Map<String,String> newProperties) {
+	public void setProperties(Map<String, Object> newProperties) {
 		properties.putAll(newProperties);
 	}
 
@@ -124,7 +124,7 @@ public class WoopraVisitor {
 	 * @param key
 	 * @param value
 	 */
-	public void setProperty(String key, String value) {
+	public void setProperty(String key, Object value) {
 		properties.put(key, value);
 	}
 }


### PR DESCRIPTION
### Purpose

- Support types besides `Strings` (e.g. numbers and booleans).
- Fix typo and format errors

### Result

Event and visitor properties should accept all data types.
All the APIs should work regardless of data type. 