### PR TITLE
MT-4465: Add scripts for publishing to maven central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## Woopra Android SDK
+# Woopra Android SDK
 
 ## Installation
-To declare the mavenCentral() repository. Add mavenCentral() in the project-level build.gradle or
-in the app module's build.gradle.
+
+To declare the mavenCentral() repository. Add mavenCentral() in the project-level build.gradle.
 ``` gradle
 allprojects {
     repositories {
@@ -13,12 +13,22 @@ allprojects {
 }
 ```
 
-Add dependencies to app/build.gradle
+Or in the app module's build.gradle
 ``` gradle
-implementation 'com.appier:woopra-android:1.1.0
+repositories {
+    ...
+    mavenCentral()
+    ...
+}
+```
+
+Then add dependencies to app/build.gradle
+``` gradle
+implementation 'com.appier:woopra-android:1.1.0'
 ```
 
 ## Instantiate Tracker Object
+
 To setup your tracker SDK, configure the tracker instance as follows (replace `mybusiness.com` with your domain name):
 
 ``` java
@@ -68,6 +78,7 @@ tracker.setVisitorProperties(visitorProps)
 ```
 
 ## Event Tracking
+
 To track an event, you must setup a `WoopraEvent` object and track it:
 
 ``` java
@@ -95,6 +106,7 @@ tracker.trackEvent(event)
 ```
 
 ## Identifying
+
 You can send an identify call without tracking an event by using the `tracker.push()` method:
 
 ``` java
@@ -118,6 +130,7 @@ tracker.push()
 ```
 
 ## Advanced Settings
+
 To add referrer information, timestamp, and other track request properties, look at the `WoopraTracker` and `WoopraEvent` class public methods for an exhaustive list of setter methods.  Here are some common examples:
 
 ### Tracker Settings

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 ## Woopra Android SDK
 
+## Installation
+To declare the mavenCentral() repository. Add mavenCentral() in the project-level build.gradle or
+in the app module's build.gradle.
+``` gradle
+allprojects {
+    repositories {
+        ...
+        mavenCentral()
+        ...
+    }
+}
+```
+
+Add dependencies to app/build.gradle
+``` gradle
+implementation 'com.appier:woopra-android:1.1.0
+```
+
 ## Instantiate Tracker Object
 To setup your tracker SDK, configure the tracker instance as follows (replace `mybusiness.com` with your domain name):
 
@@ -77,7 +95,7 @@ tracker.trackEvent(event)
 ```
 
 ## Identifying
-You can send an identify call without tracking an event by using the `tracker.push()` method: 
+You can send an identify call without tracking an event by using the `tracker.push()` method:
 
 ``` java
 // Java

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,14 @@ buildscript {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
     }
+    ext {
+        groupId = 'com.appier'
+        url = 'https://github.com/Woopra/woopra-android-sdk'
+        scmUrl = 'git@github.com:Woopra/woopra-android-sdk.git'
+        licenseName = 'MIT License'
+        licenseUrl = 'http://www.opensource.org/licenses/MIT'
+        developerEmail = 'mobile@appier.com'
+    }
 }
 
 allprojects {
@@ -20,3 +28,4 @@ allprojects {
     }
 }
 
+apply from: 'tools.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,5 @@ android.enableJetifier=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+version=1.1.0

--- a/publish-common.gradle
+++ b/publish-common.gradle
@@ -1,0 +1,62 @@
+apply plugin: 'maven-publish'
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.test.java.srcDirs
+    // It's also a good practice for a closed-source SDK to expose some API interfaces
+    // with source code, here we assume these has suffix of '.api' in there package name.
+    include("**/api/*.java")
+    include("**/api/*.kt")
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    include("**/api/*.java")
+    include("**/api/*.kt")
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    failOnError false
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            // Creates a Maven publication called "release".
+            release(MavenPublication) {
+                from components.release
+                artifact sourcesJar {
+                    classifier "sources" // this appends '-sources' to the filename of jar
+                }
+                artifact javadocJar {
+                    classifier "javadoc" // this appends '-javadoc' to the filename of jar
+                }
+                groupId = rootProject.groupId
+                artifactId = project.artifactId
+                version = version
+                pom {
+                    name = "${rootProject.groupId}:${project.artifactId}"
+                    description = project.description
+                    url = rootProject.url
+                    scm {
+                        url = rootProject.scmUrl
+                    }
+                    licenses {
+                        license {
+                            name = rootProject.licenseName
+                            url = rootProject.licenseUrl
+                        }
+                    }
+                    developers {
+                        developer {
+                            email = rootProject.developerEmail
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+apply from: "$rootProject.projectDir/publish-maven-central.gradle"

--- a/publish-maven-central.gradle
+++ b/publish-maven-central.gradle
@@ -1,0 +1,57 @@
+// Reference: https://proandroiddev.com/publishing-android-libraries-to-mavencentral-in-2021-8ac9975c3e52
+// Note: use hkp://keyserver.ubuntu.com to upload GPG key, or mavenCentral() may not find the key...
+
+apply plugin: 'signing'
+
+tasks.withType(Sign) {
+    onlyIf { !version.endsWith("SNAPSHOT") && !version.endsWith("LOCAL") }
+}
+
+ext['signing.secretKeyRingFile'] = getLocalPropertyOrEnv('signing.key.file')
+ext['signing.keyId'] = getLocalPropertyOrEnv('signing.key.id')
+ext['signing.password'] = getLocalPropertyOrEnv('signing.key.password')
+
+signing {
+    sign publishing.publications
+}
+
+ext['ossrhUsername'] = getLocalPropertyOrEnv('ossrh.username')
+ext['ossrhPassword'] = getLocalPropertyOrEnv('ossrh.password')
+
+publishing {
+    repositories {
+        maven {
+            // This is for test with local environment.
+            // DO MAKE SURE the version in gradle.properties is appended with "-LOCAL"
+            // when executing the following command for publishing:
+            // ./gradlew publish -Dpublication=release
+            // (You can specify JAVA by appending "-Dorg.gradle.java.home=/Users/${user}/Library/Java/JavaVirtualMachines/corretto-11.0.21/Contents/Home")
+            if (project.version.endsWith('-LOCAL')) {
+                String mavenLocal = "$projectDir/build/mavenLocal"
+                name = 'mavenLocal'
+                url = "file://$mavenLocal"
+            } else {
+                name = 'mavenCentral'
+                if (project.version.endsWith('-SNAPSHOT')) {
+                    // Notes about snapshot repo:
+                    // 1. There is no 'close' and 'release' workflow like in staging repo
+                    // 2. What's a SNAPSHOT version semanticallly: https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version
+                    // 3. Packages can only be resolved by using custom maven URL: `maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }`
+                    url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+                } else {
+                    // Notes about staging repo:
+                    // 1. It requires 'close' and 'release' workflow. Supposedly a closed package should only be released after QA activity.
+                    // 2. It will block versions end with '-SNAPSHOT' with '400 Bad Request'
+                    // 3. After 'close', packages can be resolved by using custom maven URL: `maven { url 'https://s01.oss.sonatype.org/content/groups/staging/' }`
+                    // 4. After 'release', packages will be sync to mavenCentral().
+                    url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+                }
+
+                credentials {
+                    username project.ossrhUsername
+                    password project.ossrhPassword
+                }
+            }
+        }
+    }
+}

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,0 +1,114 @@
+apply plugin: 'maven-publish'
+
+ext {
+    debugSuffix = '-debug'
+}
+
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    // It's also a good practice for a closed-source SDK to expose some API interfaces
+    // with source code, here we assume these has suffix of '.api' in there package name.
+    include("**/api/*.java")
+    include("**/api/*.kt")
+}
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    include("**/api/*.java")
+    include("**/api/*.kt")
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    failOnError false
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+}
+
+afterEvaluate {
+    // NOTE:
+    // This is a workaround for the known limitation by the Maven Publish plugin
+    // that appier module cannot determine which publication of the module
+    // to depend on either debug or release.
+    //
+    // See https://stackoverflow.com/questions/51247830/publishing-is-not-able-to-resolve-a-dependency-on-a-project-with-multiple-public.
+    //
+    // In order to publish releases, you must invoke publish with -Dpublication option
+    //
+    // Examples:
+    // - ./gradlew aiqua:publish -Dpublication=debug
+    // - ./gradlew aiqua:publish -Dpublication=release
+    def publication = System.getProperty('publication')
+
+    publishing {
+        publications {
+            if (publication == 'release') {
+                release(MavenPublication) {
+                    from components.release
+                    artifact sourcesJar {
+                        classifier "sources" // this appends '-sources' to the filename of jar
+                    }
+                    artifact javadocJar {
+                        classifier "javadoc" // this appends '-javadoc' to the filename of jar
+                    }
+                    groupId = rootProject.groupId
+                    artifactId = project.artifactId
+                    version = version
+                    pom {
+                        name = "${rootProject.groupId}:${project.artifactId}"
+                        description = project.description
+                        url = rootProject.url
+                        scm {
+                            url = rootProject.scmUrl
+                        }
+                        licenses {
+                            license {
+                                name = rootProject.licenseName
+                                url = rootProject.licenseUrl
+                            }
+                        }
+                        developers {
+                            developer {
+                                email = rootProject.developerEmail
+                            }
+                        }
+                    }
+                }
+            }
+            if (publication == 'debug') {
+                debug(MavenPublication) {
+                    from components.stagingDebug
+                    artifact sourcesJar {
+                        classifier "sources" // this appends '-sources' to the filename of jar
+                    }
+                    artifact javadocJar {
+                        classifier "javadoc" // this appends '-javadoc' to the filename of jar
+                    }
+                    groupId = rootProject.groupId
+                    artifactId = "${project.artifactId}${project.debugSuffix}"
+                    version = version
+                    pom {
+                        name = "${rootProject.groupId}:${project.artifactId}${project.debugSuffix}"
+                        description = project.description
+                        url = rootProject.url
+                        scm {
+                            url = rootProject.scmUrl
+                        }
+                        licenses {
+                            license {
+                                name = rootProject.licenseName
+                                url = rootProject.licenseUrl
+                            }
+                        }
+                        developers {
+                            developer {
+                                email = rootProject.developerEmail
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+apply from: "$rootProject.projectDir/publish-maven-central.gradle"

--- a/tools.gradle
+++ b/tools.gradle
@@ -1,0 +1,50 @@
+buildscript {
+    // Getting properties from 'local.properties' or environment variables.
+    // This is intended for retrieving personal attributes like app ID,
+    // API Key, or credentials (secret variables) during CI/CD process.
+    //
+    // The 'key' will be expanded to dot-style property name and
+    // underscore-style environment name. For example, 'api.key' will be
+    // expanded to 'api.key' and 'API_KEY'. And 'API_KEY' will be expanded
+    // to 'API_KEY' and 'api.key' vise versa.
+    //
+    // Similar concept can be found in golang's viper:
+    // https://github.com/spf13/viper#working-with-environment-variables
+    ext.getLocalPropertyOrEnv = { key, defaultValue = '' ->
+        def keyWithUnderscoreStyle = key.toUpperCase().replaceAll('\\.', '_')
+        def keyWithDotStyle = key.toLowerCase().replaceAll('_', '.')
+        def keys = [key, keyWithUnderscoreStyle, keyWithDotStyle].unique()
+        Properties props = new Properties()
+        // get local.properties
+        def file = rootProject.file('local.properties')
+        if (file.exists()) {
+            props.load(file.newDataInputStream())
+        }
+        for (alt in keys) {
+            def value = props.getProperty(alt)
+            if (value != null) {
+                return value
+            }
+            value = System.getenv(alt)
+            if (value != null) {
+                return value
+            }
+        }
+        // get gradle.properties
+        file = rootProject.file('gradle.properties')
+        if (file.exists()) {
+            props.load(file.newDataInputStream())
+        }
+        for (alt in keys) {
+            def value = props.getProperty(alt)
+            if (value != null) {
+                return value
+            }
+            value = System.getenv(alt)
+            if (value != null) {
+                return value
+            }
+        }
+        return defaultValue
+    }
+}

--- a/woopra/build.gradle
+++ b/woopra/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdk 21
         targetSdk 34
         versionCode 1
-        versionName "1.1.0"
+        versionName version
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -25,9 +25,25 @@ android {
     }
 }
 
+subprojects {
+    sonarqube {
+        properties {
+            property "sonar.sources", "src"
+        }
+    }
+}
+
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.21'
     testImplementation 'junit:junit:4.13.2'
 }
+
+ext {
+    artifactId = 'woopra-android'
+}
+
+description = 'Android SDK for Woopra'
+
+apply from: "$rootProject.projectDir/publish.gradle"


### PR DESCRIPTION
**Purpose**

- To add scripts for publishing SDK to maven central.
- Update README for guiding installation from maven central