### PR TITLE
chore: modify default idle timeout to 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,16 +156,16 @@ tracker.referrer = <REFERRER_STRING>
 
 #### Idle Timeout
 
-You can update your idle timeout (default: 30 seconds) by updating the timeout property in your Woopra tracker:
+You can update your idle timeout (default: 5 minutes) by updating the timeout property in your Woopra tracker:
 
 ``` java
 // Java
-tracker.setIdleTimeout(180);
+tracker.setIdleTimeout(360);
 ```
 
 ``` kotlin
 // Kotlin
-tracker.idleTimeout = 180
+tracker.idleTimeout = 360
 ```
 
 > [!NOTE]

--- a/woopra/src/main/java/com/woopra/tracking/android/WoopraTracker.java
+++ b/woopra/src/main/java/com/woopra/tracking/android/WoopraTracker.java
@@ -33,7 +33,7 @@ public class WoopraTracker {
 	private final Woopra woopraContext;
 	private final String domain;
 	// default timeout value for Woopra service
-	private long idleTimeoutMs = 30000;
+	private long idleTimeoutMs = 5 * 60 * 1000;
 
 	//
 	private String referer = null;


### PR DESCRIPTION
This PR is to modify the default idle timeout to 5 minutes to align with other platforms